### PR TITLE
correction forbidden characters

### DIFF
--- a/data/reg-idf/loc002/reg-idf.loc002.cart-enc01.xml
+++ b/data/reg-idf/loc002/reg-idf.loc002.cart-enc01.xml
@@ -1301,7 +1301,7 @@
             </div>
           </back>
         </text>
-        <text xml:id="S-Germain-en-Laye_0012" n="XII-XIII" subtype="article">
+        <text xml:id="S-Germain-en-Laye_0012" n="XIIetXIII" subtype="article">
           <pb n="22"/>
           <front>
             <docDate>

--- a/data/reg-idf/loc004/reg-idf.loc004.cart-enc01.xml
+++ b/data/reg-idf/loc004/reg-idf.loc004.cart-enc01.xml
@@ -1080,7 +1080,7 @@
             </div>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0004" n="III b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0004" n="IIIb">
           <pb n="6"/>
           <front>
             <docDate>
@@ -1113,7 +1113,7 @@
             <p/>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0005" n="III t">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0005" n="IIIt">
           <pb n="7"/>
           <front>
             <docDate>
@@ -6068,7 +6068,7 @@
             </div>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0076" n="LXXIII b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0076" n="LXXIIIb">
           <pb n="74"/>
           <front>
             <docDate>
@@ -6227,7 +6227,7 @@
             </div>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0079" n="LXXV b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0079" n="LXXVb">
           <pb n="77"/>
           <front>
             <docDate>
@@ -7019,7 +7019,7 @@
             </div>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0088" n="LXXXIII b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0088" n="LXXXIIIb">
           <pb n="89"/>
           <front>
             <docDate>
@@ -8627,7 +8627,7 @@
             </div>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0114" n="CVIII b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0114" n="CVIIIb">
           <pb n="109"/>
           <front>
             <docDate>
@@ -9741,7 +9741,7 @@
             </div>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0131" n="CXXIV b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0131" n="CXXIVb">
           <pb n="122"/>
           <front>
             <docDate>
@@ -10562,7 +10562,7 @@
             </div>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0147" n="CXXXIX b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0147" n="CXXXIXb">
           <pb n="131"/>
           <front>
             <docDate>
@@ -11472,7 +11472,7 @@
             </div>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0163" n="CLIV b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0163" n="CLIVb">
           <pb n="141"/>
           <front>
             <docDate>
@@ -11602,7 +11602,7 @@
             <p/>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0167" n="CLVII b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0167" n="CLVIIb">
           <pb n="142"/>
           <front>
             <docDate>
@@ -11908,7 +11908,7 @@
             <p/>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0175" n="CLXIV b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0175" n="CLXIVb">
           <pb n="146"/>
           <front>
             <docDate>
@@ -11935,7 +11935,7 @@
             <p/>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0176" n="CLXIV t">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0176" n="CLXIVt">
           <pb n="146"/>
           <front>
             <docDate>
@@ -11964,7 +11964,7 @@
             <p/>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0177" n="CLXIV q">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0177" n="CLXIVq">
           <pb n="146"/>
           <front>
             <docDate>
@@ -12625,7 +12625,7 @@
             </div>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0191" n="CLXXVII b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0191" n="CLXXVIIb">
           <pb n="154"/>
           <front>
             <docDate>
@@ -12689,7 +12689,7 @@
             <p/>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0193" n="CLXXVIII b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0193" n="CLXXVIIIb">
           <pb n="155"/>
           <front>
             <docDate>
@@ -12730,7 +12730,7 @@
             </div>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0194" n="CLXXVIII t">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0194" n="CLXXVIIIt">
           <pb n="155"/>
           <front>
             <docDate>
@@ -13091,7 +13091,7 @@
             <p/>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0203" n="CLXXXVI b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0203" n="CLXXXVIb">
           <pb n="159"/>
           <front>
             <docDate>
@@ -13247,7 +13247,7 @@
             <p/>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0208" n="CIC b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0208" n="CICb">
           <pb n="161"/>
           <front>
             <docDate>
@@ -13312,7 +13312,7 @@
             </div>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0209" n="CIC t">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0209" n="CICt">
           <pb n="162"/>
           <front>
             <docDate>
@@ -13433,7 +13433,7 @@
             <p/>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0212" n="CICII b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0212" n="CICIIb">
           <pb n="163"/>
           <front>
             <docDate>
@@ -13523,7 +13523,7 @@
             <p/>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0215" n="CICIV b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0215" n="CICIVb">
           <pb n="164"/>
           <front>
             <docDate>
@@ -13630,7 +13630,7 @@
             <p/>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0217" n="CICV b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0217" n="CICVb">
           <pb n="166"/>
           <front>
             <docDate>
@@ -13709,7 +13709,7 @@
             </div>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0218" n="CICV t">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0218" n="CICVt">
           <pb n="167"/>
           <front>
             <docDate>
@@ -13771,7 +13771,7 @@
             <p/>
           </body>
         </text>
-        <text subtype="article" xml:id="S-Leu-d-Esserent_0220" n="CICVI b">
+        <text subtype="article" xml:id="S-Leu-d-Esserent_0220" n="CICVIb">
           <pb n="168"/>
           <front>
             <docDate>


### PR DESCRIPTION
#40 
Nous avons supprimé les espaces dans les `@n` (ex : "XIII b" devient "XIIIb").  
Dans le loc002, la solution que nous avons trouvé n'est pas tout à fait satisfaisante mais c'est la seule qui soit correcte et explicite : "XII-XIII" est devenu "XIIetXIII". 