### PR TITLE
Modification de la casse de l'urn

### DIFF
--- a/data/reg-idf/__cts__.xml
+++ b/data/reg-idf/__cts__.xml
@@ -1,3 +1,3 @@
-<ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:FrCart:reg-idf">
+<ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:frCart:reg-idf">
   <ti:groupname xml:lang="fre">Cartulaires d'&#206;le-de-France</ti:groupname>
 </ti:textgroup>


### PR DESCRIPTION
#47 

@lduflos, on teste cette modification pour voir si nos problèmes de compatibilité viennent d'un problème de casse, où on aurait pas exemple pas le droit de commencer le nom du namespace par une majuscule... 