### PR TITLE
Ajout @xml:lang et @xml:base pour loc001 et loc002

### DIFF
--- a/data/reg-idf/loc001/reg-idf.loc001.cart-enc01.xml
+++ b/data/reg-idf/loc001/reg-idf.loc001.cart-enc01.xml
@@ -119,7 +119,7 @@
       <change when="2009-09" who="CD">suivi de numérisation</change>
     </revisionDesc>
   </teiHeader>
-  <text>
+  <text xml:lang="mul" xml:base="urn:cts:frCart:reg-idf.loc001.cart-enc01">
     <front>
       <head><hi rend="i">Cartulaire du prieuré de Saint-Christophe-en-Halatte</hi>, publié sous les
         auspices du Comité archéologique de Senlis par M. l’abbé [Amédée] Vattier, Senlis,

--- a/data/reg-idf/loc002/reg-idf.loc002.cart-enc01.xml
+++ b/data/reg-idf/loc002/reg-idf.loc002.cart-enc01.xml
@@ -134,7 +134,7 @@
       <change when="2007" who="#GP #JCM #RM">Première édition électronique</change>
     </revisionDesc>
   </teiHeader>
-  <text>
+  <text xml:lang="mul" xml:base="urn:cts:frCart:reg-idf.loc002.cart-enc01">
     <front>
       <head>Joseph Depoin, <hi rend="i">Le prieuré de Saint-Germain-en-Laye, origines et
           cartulaire</hi>, Versailles : Cerf et C<hi rend="sup">ie</hi> impimeurs, 1895,


### PR DESCRIPTION
J'ai ajouté les deux attributs à la balise ```<text>``` comme cela a été fait pour les loc003 et loc004. Issue #51 
Cela donne donc respectivement :

-> loc001 (ligne 122) : ```<text xml:lang="mul" xml:base="urn:cts:frCart:reg-idf.loc001.cart-enc01">```
-> loc002 (ligne 137) : ```<text xml:lang="mul" xml:base="urn:cts:frCart:reg-idf.loc002.cart-enc01">```

